### PR TITLE
Add draft outline for From Kernel to User series

### DIFF
--- a/content/from-kernel-to-user/0-overview.md
+++ b/content/from-kernel-to-user/0-overview.md
@@ -4,10 +4,18 @@ date = 2024-03-08T22:31:31+01:00
 draft = false
 +++
 
-This document is written to help us understand communication that generally happens from the core of the system up to the user. That is purposefully intended to give a better understanding of the mechanical complexity within software engineering and enable one to become a better software engineer.
+This series maps the path a single idea takes as it travels from the kernel to the person holding the device.
+It is a compact field guide to the conversations happening at every layer of software.
 
-I believe the only way to becoming a better Software Engineer, is to be a better communicator. Software is simply a set of instructions. And the big question is, how are we able to write a perfect and beautiful set of instructions that efficiently solves our problem? 
+Great engineers are great translators.
+We spend our time turning intent into instructions, and the only way to do that well is to communicate clearly with both machines and people.
 
-So how can I be a good communicator with computers? That would be the core story of the journey this story, we will walk through how things communicate with each other from the kernel to the user.
+These notes outline the checkpoints we will revisit in the rest of the series:
+
+- Know who you are talking to at each layer of the stack.
+- Trace how data crosses the boundaries between hardware, kernel space, and user space.
+- Shape interfaces that keep the story intact as it climbs the stack.
+- Reflect feedback from the user back into the system.
 
 [Understand your audience](/from-kernel-to-user/1-understand-your-audience/)
+

--- a/content/from-kernel-to-user/1-understand-your-audience.md
+++ b/content/from-kernel-to-user/1-understand-your-audience.md
@@ -5,9 +5,16 @@ draft = false
 +++
 
 Previous: [Overview](/from-kernel-to-user/0-overview/)
+Next: [Trace the stack](/from-kernel-to-user/2-trace-the-stack/)
 
-Depending on your interest your audience might differs, you could be web developer which means your audience is web browser, or backend engineer which means your audience is a platform like virtual machine, or some container orchestration like kubernetes/nomad etc, or you could be platform engineer which your audience would be closer to bare metal computer, or probably cloud services.
+Every layer of the stack hears a different accent.
+Browsers expect carefully structured markup, APIs listen for predictable payloads, kernels wait for syscalls that respect their contracts.
 
-In this series, I wouldn't cover all of the variations, I would focus on area that I've been involved more frequent in my career. Which starts from web development, web browser, networking, backend application, a little bit of the virtualization, then down to the kernel.
+Map the actors you depend on, then tailor your message for each one:
 
-The importance of understanding your audience is crucial to your decision making, because you can build things that is effective, but not efficient, or vice versa, efficient but not effective?
+- What inputs do they accept, and in what shape?
+- Which constraints, quotas, or timing guarantees do they enforce?
+- How do they report success, failure, or back pressure?
+
+Clarity starts with empathy for whoever—or whatever—is on the other side of the message.
+

--- a/content/from-kernel-to-user/2-trace-the-stack.md
+++ b/content/from-kernel-to-user/2-trace-the-stack.md
@@ -1,0 +1,20 @@
++++
+title = 'Trace the stack'
+date = 2024-03-10T08:00:00+01:00
+draft = false
++++
+
+Previous: [Understand your audience](/from-kernel-to-user/1-understand-your-audience/)
+Next: [Shape the interfaces](/from-kernel-to-user/3-shape-the-interfaces/)
+
+Once you know who is listening, chart how messages travel between them.
+Sketch the sequence from hardware interrupts, through kernel space, into runtimes, frameworks, and finally user-facing surfaces.
+
+Keep the overview light but explicit:
+
+- Call out where context switches happen and what they cost.
+- Note serialization, deserialization, and translation steps.
+- Highlight trust boundaries where validation must harden.
+
+A simple map exposes the friction points you will refine next.
+

--- a/content/from-kernel-to-user/3-shape-the-interfaces.md
+++ b/content/from-kernel-to-user/3-shape-the-interfaces.md
@@ -1,0 +1,20 @@
++++
+title = 'Shape the interfaces'
+date = 2024-03-11T08:00:00+01:00
+draft = false
++++
+
+Previous: [Trace the stack](/from-kernel-to-user/2-trace-the-stack/)
+Next: [Deliver to the user](/from-kernel-to-user/4-deliver-to-the-user/)
+
+Interfaces are the treaties that keep each layer in sync.
+Design them so every participant can speak succinctly and fail loudly when expectations drift.
+
+Focus on a few guardrails:
+
+- Keep contracts versioned and discoverable.
+- Automate checks that assert the contract still holds.
+- Offer observability hooks so callers learn how the system behaves in production.
+
+Well-shaped interfaces give higher layers confidence to move fast without breaking the foundation.
+

--- a/content/from-kernel-to-user/4-deliver-to-the-user.md
+++ b/content/from-kernel-to-user/4-deliver-to-the-user.md
@@ -1,0 +1,19 @@
++++
+title = 'Deliver to the user'
+date = 2024-03-12T08:00:00+01:00
+draft = false
++++
+
+Previous: [Shape the interfaces](/from-kernel-to-user/3-shape-the-interfaces/)
+
+The last hop is where humans finally experience the work hidden in the lower layers.
+Keep the handoff crisp so the narrative remains intact from kernel insight to user outcome.
+
+Anchor the delivery around three habits:
+
+- Translate system state into language and visuals the user immediately understands.
+- Close the loop with telemetry and user feedback that flows back down the stack.
+- Document the journey so future contributors can trace decisions with minimal friction.
+
+When the user receives a clear, confident experience, the conversation that started in the kernel reaches its point.
+


### PR DESCRIPTION
## Summary
- refresh the overview and audience notes with concise, link-rich introductions
- add three new outline entries that trace the path from kernel signals to the user experience

## Testing
- `hugo --panicOnWarning` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db14c6cfdc8320bbca0cdf1b7f23b6