### PR TITLE
Configure Paper theme to list posts on home page

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -4,3 +4,4 @@ title = 'behind the keyboard'
 theme = 'paper'
 [params]
     subtitle = 'failure, inefficiency, and miscommunication in software engineering'
+    mainSections = ['posts']


### PR DESCRIPTION
## Summary
- configure the Paper theme's `mainSections` parameter to include the posts section so the home page shows blog entries

## Testing
- `hugo` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_69039a7ffd1c8320916aa33c37fb4a00